### PR TITLE
feat: map and sequence improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.5
+
+- `feat`:
+  - Add `DynamicMapping` extension type that allow `Dart` values to be used as keys.
+  - Allow `block` and `flow` key anchors to be used as aliases before the entire entry is parsed.
+
+- `fix`: Ensure the end offset in an alias used as a sequence entry is updated.
+
 ## 0.0.4
 
 The parser is (fairly) stable and in a "black box" state (lexing and parsing are currently merged). You provide a source string and the parser just spits a `YamlDocument` or `YamlSourceNode` or `FormatException`. The parser cannot provide the event tree (or more contextual errors) at this time.

--- a/README.md
+++ b/README.md
@@ -327,9 +327,8 @@ const anotherListErr = '''
 >
 > An `alias` cannot be recursive. The node must be parsed completely and resolved before an `anchor` can be used. In addition to those in the spec, the parser *CURRENTLY* abides by the following rules:
 >
->1. A map groups its entries into map entry nodes. A key's `anchor` can only be referenced if the entire entry has been parsed and resolved. (This is a limitation. May be scrubbed to allow a key to be referenced before the entire entry is parsed)
->2. An `anchor` to a collection cannot be used by an entry in the same collection. In programming terms, you cannot use a variable before it has been declared or its value determined and assigned.
->3. An `anchor` can be redeclared to point to another node. Ergo, if rule `1` and `2` are satisfied and the `anchor` exists, an `alias` is valid.
+>1. An `anchor` to a collection cannot be used by an entry in the same collection. In programming terms, you cannot use a variable before it has been declared or its value determined and assigned.
+>2. An `anchor` can be redeclared to point to another node. Ergo, if rule `1` and `2` are satisfied and the `anchor` exists, an `alias` is valid.
 
 ## Tags
 

--- a/lib/src/parser/document/document_parser.dart
+++ b/lib/src/parser/document/document_parser.dart
@@ -905,7 +905,9 @@ final class DocumentParser {
                   start: flowStartOffset,
                 )
                 case ParserDelegate entry) {
-              delegate.pushEntry(entry); // TODO: Test this
+              delegate.pushEntry(
+                entry..updateEndOffset = _scanner.lineInfo().current,
+              );
               break;
             }
 

--- a/lib/src/schema/nodes/mapping.dart
+++ b/lib/src/schema/nodes/mapping.dart
@@ -5,6 +5,8 @@ part of 'yaml_node.dart';
 ///
 /// For equality, it expects at least a Dart [Map]. However, it should be noted
 /// that the value of a key will always be a [YamlSourceNode].
+///
+/// See [DynamicMapping] for a "no-cost" [Mapping] type cast.
 final class Mapping extends UnmodifiableMapView<YamlNode, YamlSourceNode?>
     implements YamlSourceNode {
   Mapping(
@@ -37,4 +39,14 @@ final class Mapping extends UnmodifiableMapView<YamlNode, YamlSourceNode?>
 
   @override
   int get hashCode => _equality.hash(this);
+}
+
+/// A "no-cost" [Mapping] that allow arbitrary `Dart` values to be used as
+/// keys to a [Mapping] without losing any type safety.
+///
+/// Optionally cast to [Map] of type [T] if you are sure all the keys match the
+/// type. Values will still be [YamlSourceNode]s
+extension type DynamicMapping<T>(Mapping mapping) implements YamlSourceNode {
+  YamlSourceNode? operator [](T key) =>
+      mapping[key is YamlNode ? key : DartNode<T>(key)];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,7 @@
 name: rookie_yaml
-description: A (rookie) YAML parser.
-version: 0.0.4
+description: A customizable (rookie) YAML parser that can parse both json and yaml.
+version: 0.0.5
 repository: https://github.com/kekavc24/rookie_yaml
-issue_tracker: https://github.com/kekavc24/rookie_yaml/issues
 topics:
   - yaml
 

--- a/test/node_properties_test.dart
+++ b/test/node_properties_test.dart
@@ -380,6 +380,42 @@ implicit-2: is-an-error}
       );
     });
 
+    test('References flow key before entire entry is parsed', () {
+      const yaml = '''
+{
+  &flow-key key: *flow-key ,
+
+  &seq-key another: [
+    *flow-key ,
+
+    &multi-line-entry
+    key: *seq-key ,
+
+    *multi-line-entry ,
+
+    &for-key key: *for-key
+  ],
+
+  *multi-line-entry
+}
+''';
+
+      check(
+        bootstrapDocParser(yaml).parseDocs().nodeAsSimpleString(),
+      ).equals(
+        {
+          'key': 'key',
+          'another': [
+            'key',
+            {'key': 'another'},
+            {'key': 'another'},
+            {'key': 'key'},
+          ],
+          {'key': 'another'}: null,
+        }.toString(),
+      );
+    });
+    
     test('Throws when non-existent alias is used', () {
       const alias = 'value';
 

--- a/test/node_properties_test.dart
+++ b/test/node_properties_test.dart
@@ -415,7 +415,22 @@ implicit-2: is-an-error}
         }.toString(),
       );
     });
-    
+
+    test('References block key before entire entry is parsed', () {
+      const yaml = '''
+&key key: *key
+
+? &another another
+: *another
+''';
+
+      check(
+        bootstrapDocParser(yaml).parseDocs().nodeAsSimpleString(),
+      ).equals(
+        {'key': 'key', 'another': 'another'}.toString(),
+      );
+    });
+
     test('Throws when non-existent alias is used', () {
       const alias = 'value';
 

--- a/test/type_inference_test.dart
+++ b/test/type_inference_test.dart
@@ -290,4 +290,25 @@ void main() {
       ..withTag().equals(tag)
       ..hasParsedInteger(24);
   });
+
+  test('Dart types can be used as keys in DynamicMapping', () {
+    const string = 'key';
+    const integer = 24;
+
+    const yaml =
+        '''
+$string: $integer
+$integer: $string
+''';
+
+    check(bootstrapDocParser(yaml).parseDocs().parseNodeSingle())
+        .isNotNull()
+        .isA<Mapping>()
+        .has((m) => m.castTo<DynamicMapping>(), 'DynamicMapping cast')
+        .which(
+          (dm) => dm
+            ..has((v) => v[string], 'String key').isNotNull()
+            ..has((v) => v[integer], 'Integer key').isNotNull(),
+        );
+  });
 }


### PR DESCRIPTION
This PR:

1. Fixes an issue where the end offset of alias entry in a `Sequence` was never updated.
2. `Mapping` improvements as described below.

## Dynamic map

Adds a "no cost" `DynamicMapping` extension type with optional key type casting. Dart values can be used as keys to a `Mapping`

```dart
void main() {
  const yaml = '''
24: hours
7: days
''';

  final root = YamlParser(
    yaml,
  ).parseNodes().first.castTo<DynamicMapping<int>>();

  print(root[24]); // hours
  print(root[7]); // days
}
```

## Key anchors as aliases in the same entry

Anchors of a key can be used before the entire entry has been parsed. This was a limitation in `v0.0.4` that has been removed.

```dart
void main() {
  const yaml = '''
&in-block block: [
  *in-block ,

  { &in-flow flow: *in-flow },

  &in-compact-flow compact-key: *in-compact-flow
 ]
''';

  final root = YamlParser(yaml).parseNodes().first.castTo<Mapping>();

  final expectedDartMap = {
    'block': [
      'block',
      {'flow': 'flow'},
      {'compact-key': 'compact-key'},
    ],
  };

  print(root.toString() == expectedDartMap.toString());
}
```