### PR TITLE
fix: parser improvements

### DIFF
--- a/lib/src/character_encoding/non_printable_characters.dart
+++ b/lib/src/character_encoding/non_printable_characters.dart
@@ -97,6 +97,7 @@ enum SpecialEscaped implements ReadableChar {
     //
     if (char
         case SpecialEscaped.backSlash ||
+            SpecialEscaped.slash ||
             WhiteSpace.space ||
             Indicator.doubleQuote) {
       return char;

--- a/lib/src/parser/scalars/block/block_scalar.dart
+++ b/lib/src/parser/scalars/block/block_scalar.dart
@@ -152,6 +152,12 @@ PreScalar parseBlockStyle(
           }
         }
 
+      // Literal & folded restricted to printable charset
+      case _ when char == null || !isPrintable(char):
+        throw FormatException(
+          'Block scalar styles are restricted to the printable character set',
+        );
+
       default:
         {
           if (char is WhiteSpace) {
@@ -175,7 +181,7 @@ PreScalar parseBlockStyle(
             lastWasIndented = false;
           }
 
-          buffer.writeChar(char!);
+          buffer.writeChar(char);
 
           // Write the remaining line to the end without including line break
           final ChunkInfo(:sourceEnded) = scanner.bufferChunk(

--- a/lib/src/parser/scalars/flow/double_quoted.dart
+++ b/lib/src/parser/scalars/flow/double_quoted.dart
@@ -18,14 +18,13 @@ const _doubleQuoteException = FormatException(
   'Expected to find a closing quote',
 );
 
-// TODO: Implicit
 /// Parses a `double quoted` scalar
 PreScalar parseDoubleQuoted(
   GraphemeScanner scanner, {
   required int indent,
   required bool isImplicit,
 }) {
-  final leadingChar = scanner.charAtCursor; // TODO: Use single variable?
+  final leadingChar = scanner.charAtCursor;
 
   if (leadingChar != _doubleQuoteIndicator) {
     throw FormatException(

--- a/lib/src/parser/scalars/flow/plain.dart
+++ b/lib/src/parser/scalars/flow/plain.dart
@@ -116,8 +116,7 @@ PreScalar? parsePlain(
 
       /// A mapping key can never be followed by a whitespace. Exit regardless
       /// of whether we folded this scalar before.
-      case _kvColon
-          when charAfter == WhiteSpace.space || charAfter is LineBreak:
+      case _kvColon when charAfter is WhiteSpace? || charAfter is LineBreak?:
         break chunker;
 
       /// A look behind condition if encountered while folding the scalar.


### PR DESCRIPTION
This PR bring various improvements:

* `ScalarStyle.block` and `ScalarStyle.folded` are now restricted to [printable characters](https://yaml.org/spec/1.2.2/#81-block-scalar-styles:~:text=There%20is%20no%20way%20to%20escape%20characters%20inside%20literal%20scalars.%20This%20restricts%20them%20to%20printable%20characters.%20In%20addition%2C%20there%20is%20no%20way%20to%20break%20a%20long%20literal%20line.)
* Fixes an issue in double quoted scalars where an escaped forward slash `/` was parsed incorrectly.
* Tabs `\t` are recognised as separation space in `YAML`. Plain scalars now treat `\t` as whitespace.

```dart
const yaml = 'key:\tvalue';

final node = YamlParser(yaml).parseNodes().first;

// Before
print(node is Scalar); // True

// Now
print(node is Scalar); // False
print(node is Mapping); // True
```