### PR TITLE
fix: allow comments in directives

### DIFF
--- a/lib/src/parser/directives/directive_utils.dart
+++ b/lib/src/parser/directives/directive_utils.dart
@@ -90,7 +90,6 @@ String _parseTagUri(
 
       /// Tag indicators must be escaped when parsing tags
       case tag when !isAnchorOrAlias:
-
         throw FormatException(
           'Expected "!" to be escaped. The "!" character must be escaped.',
         );

--- a/lib/src/parser/directives/reserved_directive.dart
+++ b/lib/src/parser/directives/reserved_directive.dart
@@ -48,15 +48,29 @@ ReservedDirective _parseReservedDirective(
 
   var current = scanner.charAtCursor;
 
-  // TODO: Include comments in directive
+  /// Reserved directives are prone to endless grouped token consumption between
+  /// with whitespace . YAML allows comments in directives (tricky).
+  /// The condition below may seem unorthodox. It's simple.
+  /// Exit if:
+  ///   1. If we have no more tokens and the char at cursor is not null
+  ///   2. If (1) stands, capture the non-null [current] and check if we reached
+  ///      the end of the line.
+  ///   3. If (2) stands, check if the captured non-null [current] is a comment
+  ///      only if the char before was non-null and a separation space
+  ///      (tab/space).
   while (scanner.canChunkMore &&
-      current.isNotNullAnd((c) => !c.isLineBreak())) {
+      current.isNotNullAnd(
+        (cursor) =>
+            !cursor.isLineBreak() &&
+            !(cursor == comment &&
+                scanner.charBeforeCursor.isNotNullAnd((c) => c.isWhiteSpace())),
+      )) {
     // Intentional switch case use!
     switch (current) {
-      /// Skip separation lines. Includes tabs. Save current parameter.
+      // Skip separation lines. Includes tabs. Save current parameter.
       case space || tab:
         {
-          scanner.skipWhitespace(skipTabs: true); // preemptive
+          scanner.skipWhitespace(skipTabs: true);
           flushBuffer();
         }
 

--- a/lib/src/parser/document/doc_parser_utils.dart
+++ b/lib/src/parser/document/doc_parser_utils.dart
@@ -93,7 +93,7 @@ bool _docIsInMarkerLine(
 ///
 /// Leading white spaces when this function is called are ignored. This
 /// function treats them as separation space including tabs.
-int? _skipToParsableChar(
+int? skipToParsableChar(
   GraphemeScanner scanner, {
   required List<YamlComment> comments,
 }) {
@@ -170,7 +170,7 @@ typedef NodeProperties = ({String? anchor, ResolvedTag? tag, String? alias});
 /// properties declared on a new line must have an indent equal to or greater
 /// than the [minIndent].
 ///
-/// See [_skipToParsableChar] which adds any comments parsed to [comments].
+/// See [skipToParsableChar] which adds any comments parsed to [comments].
 _ParsedNodeProperties _parseNodeProperties(
   GraphemeScanner scanner, {
   required int minIndent,
@@ -191,7 +191,7 @@ _ParsedNodeProperties _parseNodeProperties(
   bool isMultiline() => lfCount > 0;
 
   int? skipAndTrackLF() {
-    final indentOnExit = _skipToParsableChar(scanner, comments: comments);
+    final indentOnExit = skipToParsableChar(scanner, comments: comments);
     if (indentOnExit != null) ++lfCount;
     return indentOnExit;
   }
@@ -272,7 +272,7 @@ _ParsedNodeProperties _parseNodeProperties(
               anchor: null,
               tag: null,
             ),
-            indentOnExit: _skipToParsableChar(
+            indentOnExit: skipToParsableChar(
               scanner,
               comments: comments,
             ), // TODO: brooo this
@@ -320,7 +320,7 @@ _FlowNodeProperties _parseSimpleFlowProps(
     );
   }
 
-  if (_skipToParsableChar(scanner, comments: comments) case int indent
+  if (skipToParsableChar(scanner, comments: comments) case int indent
       when indent < minIndent) {
     throwHasLessIndent(indent);
   }

--- a/lib/src/parser/document/doc_parser_utils.dart
+++ b/lib/src/parser/document/doc_parser_utils.dart
@@ -93,12 +93,23 @@ bool _docIsInMarkerLine(
 ///
 /// Leading white spaces when this function is called are ignored. This
 /// function treats them as separation space including tabs.
+///
+/// You must provide either [comments] or an [onParseComment] [Function]
 int? skipToParsableChar(
   GraphemeScanner scanner, {
-  required List<YamlComment> comments,
+  List<YamlComment>? comments,
+  void Function(YamlComment comment)? onParseComment,
 }) {
+  assert(
+    comments != null || onParseComment != null,
+    'Missing handler/buffer to use when a comment is parsed',
+  );
+
   int? indent;
   var isLeading = true;
+
+  void addComment(YamlComment comment) =>
+      comments != null ? comments.add(comment) : onParseComment!(comment);
 
   while (scanner.canChunkMore) {
     switch (scanner.charAtCursor) {
@@ -124,7 +135,7 @@ int? skipToParsableChar(
       case comment:
         {
           final (:onExit, :comment) = parseComment(scanner);
-          comments.add(comment);
+          addComment(comment);
 
           if (onExit.sourceEnded) return null;
           indent = null; // Guarantees a recheck to indent

--- a/lib/src/parser/document/document_parser.dart
+++ b/lib/src/parser/document/document_parser.dart
@@ -167,7 +167,7 @@ final class DocumentParser {
     if (_scanner.charAtCursor case int char
         when (char.isWhiteSpace() || char.isLineBreak() || char == comment) &&
             _docEndExplicit) {
-      _skipToParsableChar(_scanner, comments: _comments);
+      skipToParsableChar(_scanner, comments: _comments);
     }
   }
 
@@ -420,7 +420,7 @@ final class DocumentParser {
   /// indicator/character must be indented at least [minIndent] spaces. Throws
   /// otherwise.
   bool _nextSafeLineInFlow(int minIndent, {required bool forceInline}) {
-    final indent = _skipToParsableChar(_scanner, comments: _comments);
+    final indent = skipToParsableChar(_scanner, comments: _comments);
 
     if (indent != null) {
       // Must not have line breaks
@@ -462,7 +462,7 @@ final class DocumentParser {
 
   /// Throws if the current char doesn't match the flow collection [delimiter]
   void _throwIfNotFlowDelimiter(int delimiter) {
-    _skipToParsableChar(_scanner, comments: _comments);
+    skipToParsableChar(_scanner, comments: _comments);
 
     final char = _scanner.charAtCursor;
 
@@ -1159,7 +1159,7 @@ final class DocumentParser {
     if (event == ScalarEvent.startFlowDoubleQuoted ||
         event == ScalarEvent.startFlowSingleQuoted ||
         charAtCursor != mappingValue) {
-      final greedyIndent = _skipToParsableChar(_scanner, comments: _comments);
+      final greedyIndent = skipToParsableChar(_scanner, comments: _comments);
 
       // The indent must be null. This must be an inlined key.
       if (greedyIndent != null || !_scanner.canChunkMore) {
@@ -1342,7 +1342,7 @@ final class DocumentParser {
 
           info = (
             docMarker: DocumentMarker.none,
-            exitIndent: _skipToParsableChar(_scanner, comments: _comments),
+            exitIndent: skipToParsableChar(_scanner, comments: _comments),
           );
         }
 
@@ -1459,7 +1459,7 @@ final class DocumentParser {
         (_scanner.charAtCursor == comment ||
             info.exitIndent == seamlessIndentMarker)) {
       info = (
-        exitIndent: _skipToParsableChar(_scanner, comments: _comments),
+        exitIndent: skipToParsableChar(_scanner, comments: _comments),
         docMarker: DocumentMarker.none,
       );
     }
@@ -1819,7 +1819,7 @@ final class DocumentParser {
     }
 
     // Must declare ":" on the same line
-    if (_skipToParsableChar(_scanner, comments: _comments) != null ||
+    if (skipToParsableChar(_scanner, comments: _comments) != null ||
         nextEvent() != BlockCollectionEvent.startEntryValue) {
       throw FormatException(
         'Expected a ":" (after the key) but found '
@@ -1839,7 +1839,7 @@ final class DocumentParser {
     _trackAnchor(implicitKey, keyProperties);
 
     _scanner.skipCharAtCursor(); // Skip ":"
-    var indentOrSeparation = _skipToParsableChar(_scanner, comments: _comments);
+    var indentOrSeparation = skipToParsableChar(_scanner, comments: _comments);
 
     final minValueIndent = parentIndent + 1;
     final valueIndentLevel = parentIndentLevel + 1;
@@ -1989,7 +1989,7 @@ final class DocumentParser {
         when _scanner.canChunkMore &&
             !marker.stopIfParsingDoc &&
             indentOnExit == seamlessIndentMarker) {
-      indentOnExit = _skipToParsableChar(_scanner, comments: _comments);
+      indentOnExit = skipToParsableChar(_scanner, comments: _comments);
     }
 
     return (
@@ -2205,8 +2205,7 @@ final class DocumentParser {
         ///
         /// TODO: Remove zero indent for doc end chars? Mulling 🤔
         /// TODO: Should doc end chars hug left or just have any indent?
-        case blockSequenceEntry || period
-            when indent == 0 && charAfter == char:
+        case blockSequenceEntry || period when indent == 0 && charAfter == char:
           {
             if (checkForDocumentMarkers(_scanner, onMissing: (_) {})
                 case DocumentMarker docType when docType.stopIfParsingDoc) {
@@ -2482,7 +2481,7 @@ final class DocumentParser {
         isDocStartExplicit: _docStartExplicit,
       );
 
-      var rootIndent = _skipToParsableChar(_scanner, comments: _comments);
+      var rootIndent = skipToParsableChar(_scanner, comments: _comments);
       final rootStartOffset = _scanner.lineInfo().current;
 
       _throwIfUnsafeForDirectiveChar(
@@ -2539,7 +2538,7 @@ final class DocumentParser {
         /// Also implicit maps cannot start on "---" line
         if (!_rootInMarkerLine &&
             !key.encounteredLineBreak &&
-            _skipToParsableChar(
+            skipToParsableChar(
                   _scanner,
                   comments: _comments,
                 ) ==
@@ -2616,7 +2615,7 @@ final class DocumentParser {
       /// We must see document end chars and don't care how they are laid within
       /// the document. At this point the document is or should be complete
       if (rootInfo == null || !rootInfo.docMarker.stopIfParsingDoc) {
-        _skipToParsableChar(_scanner, comments: _comments);
+        skipToParsableChar(_scanner, comments: _comments);
 
         final fauxBuffer = <String>[];
 

--- a/lib/src/parser/document/document_parser.dart
+++ b/lib/src/parser/document/document_parser.dart
@@ -2411,6 +2411,7 @@ final class DocumentParser {
         :hasDirectiveEnd,
       ) = parseDirectives(
         _scanner,
+        onParseComment: _comments.add,
       );
 
       _hasDirectives =

--- a/lib/src/scanner/scalar_buffer.dart
+++ b/lib/src/scanner/scalar_buffer.dart
@@ -2,8 +2,7 @@ import 'package:rookie_yaml/src/scanner/chunk_scanner.dart';
 
 /// A [StringBuffer] wrapper for buffering scalars.
 final class ScalarBuffer {
-  ScalarBuffer([StringBuffer? buffer])
-    : _buffer = buffer ?? StringBuffer();
+  ScalarBuffer([StringBuffer? buffer]) : _buffer = buffer ?? StringBuffer();
 
   /// Actual buffer
   final StringBuffer _buffer;

--- a/test/helpers/model_helpers.dart
+++ b/test/helpers/model_helpers.dart
@@ -15,6 +15,9 @@ final flowDelimiters = Iterable.withIterator(
   ].map((e) => e.asString()).iterator,
 );
 
+Directives vanillaDirectives(String yaml) =>
+    parseDirectives(GraphemeScanner.of(yaml), onParseComment: (_) {});
+
 T _inferredValue<T>(Scalar<T> scalar) => scalar.value;
 
 extension PreScalarHelper on Subject<PreScalar?> {

--- a/test/tags_test.dart
+++ b/test/tags_test.dart
@@ -56,7 +56,7 @@ void main() {
 
       final handle = TagHandle.primary();
 
-      check(parseDirectives(GraphemeScanner.of(yaml)))
+      check(vanillaDirectives(yaml))
           .has((d) => d.globalTags, 'Global Tag from tag uri')
           .deepEquals({handle: GlobalTag.fromTagUri(handle, uriPrefix)});
     });
@@ -71,7 +71,7 @@ void main() {
 
       final handle = TagHandle.secondary();
 
-      check(parseDirectives(GraphemeScanner.of(yaml)))
+      check(vanillaDirectives(yaml))
           .has((d) => d.globalTags, 'Global Tag from tag uri')
           .deepEquals({handle: GlobalTag.fromTagUri(handle, uriPrefix)});
     });
@@ -87,7 +87,7 @@ void main() {
 
       final handle = TagHandle.named(named);
 
-      check(parseDirectives(GraphemeScanner.of(yaml)))
+      check(vanillaDirectives(yaml))
           .has((d) => d.globalTags, 'Global Tag from tag uri')
           .deepEquals({handle: GlobalTag.fromTagUri(handle, uriPrefix)});
     });
@@ -104,7 +104,7 @@ void main() {
       final handle = TagHandle.named(name);
 
       check(
-        parseDirectives(GraphemeScanner.of(yaml)),
+        vanillaDirectives(yaml),
       ).has((d) => d.globalTags, 'Global Tag from tag uri').deepEquals({
         handle: GlobalTag.fromTagShorthand(
           handle,
@@ -118,9 +118,7 @@ void main() {
 %TAG ! !foo
 %TAG ! !foo''';
 
-      check(
-        () => parseDirectives(GraphemeScanner.of(yaml)),
-      ).throwsAFormatException(
+      check(() => vanillaDirectives(yaml)).throwsAFormatException(
         'A global tag directive with the "!" has already '
         'been declared in this document',
       );
@@ -132,9 +130,7 @@ void main() {
       () {
         final yaml = '%TAG !no-prefix-or-separation-after!';
 
-        check(
-          () => parseDirectives(GraphemeScanner.of(yaml)),
-        ).throwsAFormatException(
+        check(() => vanillaDirectives(yaml)).throwsAFormatException(
           'A global tag must have a separation space after its handle',
         );
       },
@@ -145,9 +141,7 @@ void main() {
       () {
         final yaml = '%TAG !no-uri-or-local-tag-prefix! ';
 
-        check(
-          () => parseDirectives(GraphemeScanner.of(yaml)),
-        ).throwsAFormatException(
+        check(() => vanillaDirectives(yaml)).throwsAFormatException(
           'A global tag only accepts valid uri characters as a tag prefix',
         );
       },
@@ -160,9 +154,7 @@ void main() {
             '%TAG !no-uri-or-local-tag-prefix! '
             '${bell.asString()}';
 
-        check(
-          () => parseDirectives(GraphemeScanner.of(yaml)),
-        ).throwsAFormatException(
+        check(() => vanillaDirectives(yaml)).throwsAFormatException(
           'A global tag only accepts valid uri characters as a tag prefix',
         );
       },


### PR DESCRIPTION
This PR allow comments in directives to be parsed correctly without throwing errors

```dart
const yaml = '''
%YAML 1.2 # We only support YAML version 1.2+
---
Noice!
''';

print(YamlParser(yaml).parseDocuments().first.comments.first); // # We only support YAML version 1.2+
```