### PR TITLE
fix: ensure aliases are handled correctly in sequences

### DIFF
--- a/test/node_properties_test.dart
+++ b/test/node_properties_test.dart
@@ -435,6 +435,47 @@ implicit-2: is-an-error}
       );
     });
 
+    test('Parses trailing flow sequence aliases', () {
+      const yaml = '''
+[
+  &anchor value,
+
+  [ *anchor ], # Single trailing
+  [ *anchor , *anchor ],
+  *anchor
+]
+''';
+
+      check(
+        bootstrapDocParser(yaml).parseDocuments().nodeAsSimpleString(),
+      ).equals(
+        [
+          'value',
+          ['value'],
+          ['value', 'value'],
+          'value',
+        ].toString(),
+      );
+    });
+
+    test('Parses compact block map with alias as key in block sequence', () {
+      const yaml = '''
+- &anchor value
+- *anchor
+- *anchor : *anchor
+''';
+
+      check(
+        bootstrapDocParser(yaml).parseDocuments().nodeAsSimpleString(),
+      ).equals(
+        [
+          'value',
+          'value',
+          {'value': 'value'},
+        ].toString(),
+      );
+    });
+
     test('Throws when non-existent alias is used', () {
       const alias = 'value';
 


### PR DESCRIPTION
* Prevent trailing aliases in a flow sequence from being ignored.
* Ensure implicit block maps with alias keys in a block sequences are parsed completely. We needed to ensure that the alias behaved the same way as a block scalar that is the first key to an implicit block map.
* Add tests to prevent regressions in future