### PR TITLE
refactor: ensure `AliasNode` uses reference for equality

### DIFF
--- a/lib/src/schema/nodes/mapping.dart
+++ b/lib/src/schema/nodes/mapping.dart
@@ -1,10 +1,9 @@
 part of 'yaml_node.dart';
 
-/// A read-only `YAML` [Map]. A mapping may allow a `null` key but it must be
-/// wrapped by a [Scalar].
+/// A read-only `YAML` [Map] which mirrors an actual Dart [Map] in equality
+/// but not shape.
 ///
-/// For equality, it expects at least a Dart [Map]. However, it should be noted
-/// that the value of a key will always be a [YamlSourceNode].
+/// A mapping may allow a `null` key but it must be  wrapped by a [Scalar].
 ///
 /// See [DynamicMapping] for a "no-cost" [Mapping] type cast.
 final class Mapping extends DelegatingMap<YamlNode, YamlSourceNode?>
@@ -58,10 +57,10 @@ final class Mapping extends DelegatingMap<YamlNode, YamlSourceNode?>
 
   @override
   bool operator ==(Object other) =>
-      other is Map && _equality.equals(this, other);
+      other is Map && yamlCollectionEquality.equals(this, other);
 
   @override
-  int get hashCode => _equality.hash(this);
+  int get hashCode => yamlCollectionEquality.hash(this);
 
   @override
   String? get alias => null;

--- a/lib/src/schema/nodes/sequence.dart
+++ b/lib/src/schema/nodes/sequence.dart
@@ -1,6 +1,7 @@
 part of 'yaml_node.dart';
 
-/// A read-only `YAML` [List]
+/// A read-only `YAML` [List] which mirrors an actual Dart [List] in equality
+/// but not shape.
 final class Sequence extends DelegatingList<YamlSourceNode>
     with NonGrowableListMixin<YamlSourceNode>
     implements YamlSourceNode {
@@ -30,10 +31,10 @@ final class Sequence extends DelegatingList<YamlSourceNode>
 
   @override
   bool operator ==(Object other) =>
-      other is List && _equality.equals(this, other);
+      other is Iterable && yamlCollectionEquality.equals(this, other);
 
   @override
-  int get hashCode => _equality.hash(this);
+  int get hashCode => yamlCollectionEquality.hash(this);
 
   @override
   String? get alias => null;

--- a/lib/src/schema/nodes/yaml_node.dart
+++ b/lib/src/schema/nodes/yaml_node.dart
@@ -8,7 +8,13 @@ part 'node_styles.dart';
 part 'scalar.dart';
 part 'sequence.dart';
 
-const _equality = DeepCollectionEquality();
+/// A custom [Equality] object for deep equality. This includes [AliasNode]s
+/// which wrap their [YamlSourceNode] subclass references.
+final yamlCollectionEquality = DeepCollectionEquality(
+  EqualityBy<Object, Object>(
+    (e) => e is AliasNode ? e.aliased : e,
+  ),
+);
 
 /// A simple node dumpable to a `YAML` source string
 sealed class YamlNode {
@@ -108,10 +114,11 @@ final class AliasNode extends YamlSourceNode {
   NodeStyle get nodeStyle => aliased.nodeStyle;
 
   @override
-  bool operator ==(Object other) => _equality.equals(aliased, other);
+  bool operator ==(Object other) =>
+      yamlCollectionEquality.equals(aliased, other);
 
   @override
-  int get hashCode => _equality.hash(aliased);
+  int get hashCode => yamlCollectionEquality.hash(aliased);
 
   @override
   String toString() => aliased.toString();
@@ -134,8 +141,8 @@ final class DartNode<T> extends YamlNode {
   NodeStyle get nodeStyle => NodeStyle.block;
 
   @override
-  bool operator ==(Object other) => _equality.equals(other, value);
+  bool operator ==(Object other) => yamlCollectionEquality.equals(other, value);
 
   @override
-  int get hashCode => _equality.hash(value);
+  int get hashCode => yamlCollectionEquality.hash(value);
 }


### PR DESCRIPTION
* Expose equality object for external use