### PR TITLE
refactor: implement custom equality

### DIFF
--- a/lib/src/schema/nodes/mapping.dart
+++ b/lib/src/schema/nodes/mapping.dart
@@ -56,8 +56,7 @@ final class Mapping extends DelegatingMap<YamlNode, YamlSourceNode?>
   final SourceLocation end;
 
   @override
-  bool operator ==(Object other) =>
-      other is Map && yamlCollectionEquality.equals(this, other);
+  bool operator ==(Object other) => yamlCollectionEquality.equals(this, other);
 
   @override
   int get hashCode => yamlCollectionEquality.hash(this);

--- a/lib/src/schema/nodes/sequence.dart
+++ b/lib/src/schema/nodes/sequence.dart
@@ -30,8 +30,7 @@ final class Sequence extends DelegatingList<YamlSourceNode>
   final SourceLocation end;
 
   @override
-  bool operator ==(Object other) =>
-      other is Iterable && yamlCollectionEquality.equals(this, other);
+  bool operator ==(Object other) => yamlCollectionEquality.equals(this, other);
 
   @override
   int get hashCode => yamlCollectionEquality.hash(this);

--- a/lib/src/schema/nodes/yaml_node.dart
+++ b/lib/src/schema/nodes/yaml_node.dart
@@ -10,11 +10,29 @@ part 'sequence.dart';
 
 /// A custom [Equality] object for deep equality. This includes [AliasNode]s
 /// which wrap their [YamlSourceNode] subclass references.
-final yamlCollectionEquality = DeepCollectionEquality(
-  EqualityBy<Object, Object>(
-    (e) => e is AliasNode ? e.aliased : e,
-  ),
-);
+///
+/// {@category yaml_nodes}
+const yamlCollectionEquality = YamlCollectionEquality();
+
+/// A [DeepCollectionEquality] implementation that treats [YamlSourceNode]s as
+/// immutable Dart objects.
+final class YamlCollectionEquality extends DeepCollectionEquality {
+  const YamlCollectionEquality();
+
+  static Object? _unpack(Object? object) => switch (object) {
+    AliasNode(:final aliased) => aliased,
+    _ => object,
+  };
+
+  @override
+  bool equals(Object? e1, Object? e2) => super.equals(_unpack(e1), _unpack(e2));
+
+  @override
+  int hash(Object? o) => super.hash(_unpack(o));
+
+  @override
+  bool isValidKey(Object? o) => super.isValidKey(_unpack(o));
+}
 
 /// A simple node dumpable to a `YAML` source string
 sealed class YamlNode {
@@ -114,11 +132,10 @@ final class AliasNode extends YamlSourceNode {
   NodeStyle get nodeStyle => aliased.nodeStyle;
 
   @override
-  bool operator ==(Object other) =>
-      yamlCollectionEquality.equals(aliased, other);
+  bool operator ==(Object other) => aliased == other;
 
   @override
-  int get hashCode => yamlCollectionEquality.hash(aliased);
+  int get hashCode => aliased.hashCode;
 
   @override
   String toString() => aliased.toString();


### PR DESCRIPTION
* Unpack the `AliasNode` by default when attempting to check for equality.