### PR TITLE
fix: dump compact nodes correctly

### DIFF
--- a/lib/src/dumping/dump_yaml_node.dart
+++ b/lib/src/dumping/dump_yaml_node.dart
@@ -36,7 +36,7 @@ _UnpackedCompact _unpackCompactYamlNode(
   required bool Function(String alias) hasAlias,
   required void Function(String anchor) pushAnchor,
   required void Function(String globalTag) pushTag,
-  required Object Function(CompactYamlNode node) unpack,
+  required Object? Function(CompactYamlNode node) unpack,
 }) {
   var toUnpack = node;
 
@@ -98,7 +98,7 @@ _UnpackedCompact _unpackCompactYamlNode(
 /// Dumps a [node] and its properties.
 String _dumpCompactYamlNode<N extends CompactYamlNode>(
   N node, {
-  required Object Function(N node)? nodeUnpacker,
+  required Object? Function(N node)? nodeUnpacker,
   required ScalarStyle scalarStyle,
   YamlDirective? directive,
   Set<GlobalTag<dynamic>>? tags,
@@ -109,7 +109,7 @@ String _dumpCompactYamlNode<N extends CompactYamlNode>(
   /// Spoof the unpacking function. [YamlSourceNode]s are dumped on our terms
   /// since we extend native Dart objects (even the Scalar is a clever
   /// abstraction around a string to support custom types!).
-  Object unpack(CompactYamlNode node) {
+  Object? unpack(CompactYamlNode node) {
     /// Dart allows extension types. They are stripped but the underlying
     /// type is still a YamlSourceNode.
     return node is YamlSourceNode
@@ -179,7 +179,7 @@ String dumpYamlNode<N extends YamlNode>(
 /// {@category dump_doc}
 String dumpCompactNode<N extends CompactYamlNode>(
   N node, {
-  required Object Function(N node)? nodeUnpacker,
+  required Object? Function(N node)? nodeUnpacker,
   ScalarStyle scalarStyle = ScalarStyle.plain,
 }) => _dumpCompactYamlNode(
   node,

--- a/lib/src/dumping/dumping.dart
+++ b/lib/src/dumping/dumping.dart
@@ -181,7 +181,10 @@ _DumpedObjectInfo _encodeObject<T>(
       );
     }
 
-    style = styleOverride ?? style;
+    /// Only block styles can be overriden in case the child has node properties
+    style = styleOverride != null && style != NodeStyle.flow
+        ? styleOverride
+        : style;
     encodable = toEncode;
     objectProperties = properties;
   }

--- a/test/dump_yaml_node_test.dart
+++ b/test/dump_yaml_node_test.dart
@@ -217,6 +217,27 @@ $globalFromUri
 ...''');
     });
 
+    test("Prevents child block style override on parent flow's style", () {
+      final object = _TestObject(
+        [
+          'clean',
+          _TestObject(['value'], style: NodeStyle.block),
+        ],
+        anchor: 'parent',
+      );
+
+      check(_dumpTestObject(object)).equals('''
+%YAML 1.2
+---
+&parent [
+ clean,
+ [
+  value
+ ]
+]
+...''');
+    });
+
     test(
       'Throws an assertion error when a tag declared is not a valid YAML tag '
       'if the secondary tag handle is used',


### PR DESCRIPTION
Changes in this PR:

- Allows `null` to be returned in the unpacking function in `_dumpCompactNode`
- Prevents block style from being included in flow style when dumping a `CompactYamlNode`