### PR TITLE
refactor: parser improvements

### DIFF
--- a/lib/src/parser/directives/directive_utils.dart
+++ b/lib/src/parser/directives/directive_utils.dart
@@ -76,11 +76,7 @@ String _parseTagUri(
       /// Alias/anchor names does not allow them.
       case _ when !allowFlowIndicators && char.isFlowDelimiter():
         {
-          if (isAnchorOrAlias) {
-            throw FormatException(
-              'Anchor/alias names must not contain flow indicators',
-            );
-          }
+          if (isAnchorOrAlias) break tagParser;
 
           throw FormatException(
             'Expected "${char.asString()}" to be escaped. '

--- a/lib/src/parser/directives/global_tag.dart
+++ b/lib/src/parser/directives/global_tag.dart
@@ -24,10 +24,11 @@ final class GlobalTag<T> extends SpecificTag<T> implements Directive {
     : super.fromTagShorthand();
 
   /// Creates a global tag whose prefix is a valid tag uri
-  factory GlobalTag.fromTagUri(TagHandle handle, String uri) => GlobalTag._(
-    handle,
-    _ensureIsTagUri(uri, allowRestrictedIndicators: true),
-  );
+  GlobalTag.fromTagUri(TagHandle handle, String uri)
+    : this._(
+        handle,
+        _ensureIsTagUri(uri, allowRestrictedIndicators: true),
+      );
 
   @override
   String get name => _globalTagDirective;

--- a/lib/src/parser/directives/node_tag.dart
+++ b/lib/src/parser/directives/node_tag.dart
@@ -42,7 +42,7 @@ String _formatAsVerbatim(
 /// {@category tag_types}
 /// {@category declare_tags}
 final class NodeTag<T> extends ResolvedTag {
-  NodeTag(this._resolvedTag, TagShorthand? suffix)
+  NodeTag(this._resolvedTag, [TagShorthand? suffix])
     : verbatim = _formatAsVerbatim(
         _resolvedTag,
         suffix?.content ?? '',

--- a/lib/src/parser/directives/reserved_directive.dart
+++ b/lib/src/parser/directives/reserved_directive.dart
@@ -51,15 +51,15 @@ ReservedDirective _parseReservedDirective(
   var current = scanner.charAtCursor;
 
   /// Reserved directives are prone to endless grouped token consumption between
-  /// with whitespace . YAML allows comments in directives (tricky).
-  /// The condition below may seem unorthodox. It's simple.
+  /// with whitespace. YAML allows comments in directives (tricky). The
+  /// condition below may seem unorthodox. It's simple.
   /// Exit if:
   ///   1. If we have no more tokens and the char at cursor is not null
   ///   2. If (1) stands, capture the non-null [current] and check if we reached
   ///      the end of the line.
-  ///   3. If (2) stands, check if the captured non-null [current] is a comment
-  ///      only if the char before was non-null and a separation space
-  ///      (tab/space).
+  ///   3. If (2) stands (we never reached the end of the line), check if the
+  ///      captured non-null [current] is a comment only if the char before was
+  ///      non-null and a separation space (tab/space).
   while (scanner.canChunkMore &&
       current.isNotNullAnd(
         (cursor) =>

--- a/lib/src/parser/document/document_parser.dart
+++ b/lib/src/parser/document/document_parser.dart
@@ -201,9 +201,10 @@ final class DocumentParser {
     _lastWasDocEndChars = marker.indicator;
     _docEndExplicit = marker == DocumentMarker.documentEnd;
 
-    if (_scanner.charAtCursor case int char
-        when (char.isWhiteSpace() || char.isLineBreak() || char == comment) &&
-            _docEndExplicit) {
+    if (_docEndExplicit &&
+        _scanner.charAtCursor.isNotNullAnd(
+          (c) => c == comment || c.isWhiteSpace() || c.isLineBreak(),
+        )) {
       skipToParsableChar(_scanner, comments: _comments);
     }
   }

--- a/lib/src/scanner/chunk_scanner.dart
+++ b/lib/src/scanner/chunk_scanner.dart
@@ -74,7 +74,8 @@ final class GraphemeScanner {
   /// Character at the cursor
   int? _charOnLastExit;
 
-  ///
+  /// Returns the current offset of this scanner and the actual start offset of
+  /// the current [LineSpan].
   LineRangeInfo lineInfo() {
     if (_currentLine == null) {
       _fetchNextLine();


### PR DESCRIPTION
* Prefer checking if document is explicit first before checking current character.
* Prefer stopping the parsing of an anchor/alias instead of throwing an exception when a flow indicator is seen